### PR TITLE
Fix bug in trading environment and data utilities

### DIFF
--- a/Chapter21/trading_env.py
+++ b/Chapter21/trading_env.py
@@ -291,10 +291,10 @@ class TradingEnvironment(gym.Env):
             For training purposes, you might not want to set both.
         """
         logfile = None
+        need_df = write_log or return_df
         if write_log:
             logfile = tempfile.NamedTemporaryFile(delete=False, mode='w+')
             log.info('writing log to %s', logfile.name)
-            need_df = write_log or return_df
 
         alldf = None
 

--- a/data/get_data.py
+++ b/data/get_data.py
@@ -23,7 +23,7 @@ def get_wiki_prices():
         store.put('quandl/wiki/prices', df)
 
 
-def get_wiki_constitutents():
+def get_wiki_constituents():
     """source: https://www.quandl.com/api/v3/databases/WIKI/codes?api_key=<API_KEY>
         Download and rename to wiki_stocks.csv
     """
@@ -33,7 +33,7 @@ def get_wiki_constitutents():
     df.columns = ['symbol', 'name']
     print(df.info(null_counts=True))
     with pd.HDFStore('assets.h5') as store:
-        store.put('quandl/wiki/prices', df)
+        store.put('quandl/wiki/stocks', df)
 
 
 def get_sp500_prices():


### PR DESCRIPTION
## Summary
- ensure variable `need_df` is defined regardless of logging
- rename `get_wiki_constituents` and store to correct location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for bs4 and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685fba9296e48325a8fe0befebdcfa10